### PR TITLE
Add photo naming feature

### DIFF
--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -77,7 +77,7 @@ def _load_defaults():
     return {}
 
 
-def download_set(set_id, size_label=None, naming='append'):
+def download_set(set_id, size_label=None, naming=None):
     """
     Download the set with 'set_id' to the current directory.
 


### PR DESCRIPTION
In some photo sets, pictures titles are duplicated, even if the pictures are all different. Since this project is bound to the photo’s title to create the file name, in photo sets like this, after it downloaded and stored the first photo, it would skip the next photos with the same name.
Now you can rename the photos, append its ID to the file name, just increment the filename or maintain the default behaviour of skipping.
