### PR TITLE
Fix downloading filenames containing forward slashes

### DIFF
--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -79,6 +79,7 @@ def _load_defaults():
 
     return {}
 
+
 def validate_filename(filename):
     """
     Validate the characters in the filename to avoid things like forward
@@ -87,6 +88,7 @@ def validate_filename(filename):
     """
     valid_chars = "-_.() %s%s" % (string.ascii_letters, string.digits)
     return ''.join(c for c in filename if c in valid_chars)
+
 
 def download_set(set_id, get_filename, size_label=None):
     """


### PR DESCRIPTION
Hey I recently came on this project while trying to download some photos from one of my albums. If you want a repro case, here's one of my albums that contains several files with forward slashes in their name:
flickr_download -d 72157639469468893

I threw in a pretty hacky filename validator to avoid the crash. It works for my specific case but there really isn't a great solution when you have to yank out 1 or more characters from a filename. Anyhow, thought I'd throw this upstream. Thanks for the project!
