### PR TITLE
download HD MP4 if video

### DIFF
--- a/flickr_download/filename_handlers.py
+++ b/flickr_download/filename_handlers.py
@@ -34,7 +34,7 @@ def title(pset, photo, suffix):
     if not photo.title:
         return idd(pset, photo, suffix)
 
-    return '{0}{1}.jpg'.format(photo.title, suffix)
+    return '{0}{1}'.format(photo.title, suffix)
 
 
 def idd(pset, photo, suffix):
@@ -46,7 +46,7 @@ def idd(pset, photo, suffix):
     @param suffice: str, optional suffix
     @return: str, the filename
     """
-    return '{0}{1}.jpg'.format(photo.id, suffix)
+    return '{0}{1}'.format(photo.id, suffix)
 
 
 def title_and_id(pset, photo, suffix):
@@ -61,7 +61,7 @@ def title_and_id(pset, photo, suffix):
     if not photo.title:
         return idd(pset, photo, suffix)
 
-    return '{0}-{1}{2}.jpg'.format(photo.title, photo.id, suffix)
+    return '{0}-{1}{2}'.format(photo.title, photo.id, suffix)
 
 
 INCREMENT_INDEX = defaultdict(lambda: defaultdict(int))
@@ -85,7 +85,7 @@ def title_increment(pset, photo, suffix):
     if photo_index:
         extra = '({0})'.format(photo_index)
     INCREMENT_INDEX[pset.id][photo.title] += 1
-    return '{0}{1}{2}.jpg'.format(photo.title, suffix, extra)
+    return '{0}{1}{2}'.format(photo.title, suffix, extra)
 
 
 HANDLERS = {

--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -115,9 +115,10 @@ def download_set(set_id, get_filename, size_label=None):
         fname = get_full_path(dirname, get_filename(pset, photo, suffix))
 
         if 'video' in photo.getInfo():
-            size_label = 'HD MP4'
+            photo_size_label = 'HD MP4'
             fname = fname + '.mp4'
         else:
+            photo_size_label = size_label
             fname = fname + '.jpg'
 
         if os.path.exists(fname):
@@ -127,7 +128,7 @@ def download_set(set_id, get_filename, size_label=None):
             continue
 
         print('Saving: {0}'.format(fname))
-        photo.save(fname, size_label)
+        photo.save(fname, photo_size_label)
 
         # Set file times to when the photo was taken
         info = photo.getInfo()

--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -113,6 +113,8 @@ def download_set(set_id, get_filename, size_label=None):
 
     for photo in photos:
         fname = get_full_path(dirname, get_filename(pset, photo, suffix))
+        if 'video' in photo.getInfo():
+            fname = fname[:-3] + 'mp4'
         if os.path.exists(fname):
             # TODO: Ideally we should check for file size / md5 here
             # to handle failed downloads.
@@ -120,7 +122,12 @@ def download_set(set_id, get_filename, size_label=None):
             continue
 
         print('Saving: {0}'.format(fname))
-        photo.save(fname, size_label)
+
+        if ('video' in photo.getInfo()):
+            photo.save(fname, 'HD MP4')
+        else:
+            photo.save(fname, size_label)
+
 
         # Set file times to when the photo was taken
         info = photo.getInfo()

--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -113,8 +113,13 @@ def download_set(set_id, get_filename, size_label=None):
 
     for photo in photos:
         fname = get_full_path(dirname, get_filename(pset, photo, suffix))
+
         if 'video' in photo.getInfo():
-            fname = fname[:-3] + 'mp4'
+            size_label = 'HD MP4'
+            fname = fname + '.mp4'
+        else:
+            fname = fname + '.jpg'
+
         if os.path.exists(fname):
             # TODO: Ideally we should check for file size / md5 here
             # to handle failed downloads.
@@ -122,12 +127,7 @@ def download_set(set_id, get_filename, size_label=None):
             continue
 
         print('Saving: {0}'.format(fname))
-
-        if ('video' in photo.getInfo()):
-            photo.save(fname, 'HD MP4')
-        else:
-            photo.save(fname, size_label)
-
+        photo.save(fname, size_label)
 
         # Set file times to when the photo was taken
         info = photo.getInfo()

--- a/tests/filename_handlers.py
+++ b/tests/filename_handlers.py
@@ -14,53 +14,53 @@ class TestFilenameHandlers(unittest.TestCase):
     def test_title(self):
         fn = get_filename_handler('title')
         self.assertEqual(fn(self._pset, self._photo, self._suffix),
-                         'Some Photo.jpg')
+                         'Some Photo')
 
     def test_title_empty_title(self):
         photo = AttrDict({'title': '', 'id': 192})
         fn = get_filename_handler('title')
         self.assertEqual(fn(self._pset, photo, self._suffix),
-                         '192.jpg')
+                         '192')
 
     def test_title_and_id(self):
         fn = get_filename_handler('title_and_id')
         self.assertEqual(fn(self._pset, self._photo, self._suffix),
-                         'Some Photo-123.jpg')
+                         'Some Photo-123')
 
     def test_title_and_id_empty_title(self):
         photo = AttrDict({'title': '', 'id': 1389})
         fn = get_filename_handler('title_and_id')
         self.assertEqual(fn(self._pset, photo, self._suffix),
-                         '1389.jpg')
+                         '1389')
 
     def test_id(self):
         fn = get_filename_handler('id')
         self.assertEqual(fn(self._pset, self._photo, self._suffix),
-                         '123.jpg')
+                         '123')
 
     def test_title_increment(self):
         fn = get_filename_handler('title_increment')
         # Ensure increment on same title
         self.assertEqual(fn(self._pset, self._photo, self._suffix),
-                         'Some Photo.jpg')
+                         'Some Photo')
         self.assertEqual(fn(self._pset, self._photo, self._suffix),
-                         'Some Photo(1).jpg')
+                         'Some Photo(1)')
 
         # Ensure no increment on different title
         photo2 = AttrDict({'title': 'Some Other Photo', 'id': 124})
         self.assertEqual(fn(self._pset, photo2, self._suffix),
-                         'Some Other Photo.jpg')
+                         'Some Other Photo')
 
         # Ensure no increment on same title, but different set
         pset2 = AttrDict({'title': 'Some Other Set', 'id': 1000})
         self.assertEqual(fn(pset2, self._photo, self._suffix),
-                         'Some Photo.jpg')
+                         'Some Photo')
 
     def test_title_increment_empty_title(self):
         photo = AttrDict({'title': '', 'id': 175})
         fn = get_filename_handler('title_increment')
         self.assertEqual(fn(self._pset, photo, self._suffix),
-                         '175.jpg')
+                         '175')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Thanks for the wonderful package. I tried to use the package to download some photos and videos, and found that Flickr would download the "snapshot photo" of videos instead of the videos. So I added some lines to download the actual (HD MP4) videos.