### PR TITLE
Add python 3 support

### DIFF
--- a/flickr_download/filename_handlers.py
+++ b/flickr_download/filename_handlers.py
@@ -117,7 +117,7 @@ def get_filename_handler_help():
     @return: str, help text
     """
     ret = []
-    for name, func in HANDLERS.iteritems():
+    for name, func in HANDLERS.items():
         ret.append('  {handler} - {doc}{default}'
                    .format(handler=name,
                            doc=_get_short_docstring(func.__doc__),

--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -57,7 +57,7 @@ def _init(key, secret, oauth):
     print(url)
     print("Copy and paste the <oauth_verifier> value from XML here and press return:")
     Flickr.set_auth_handler(auth)
-    token = raw_input()
+    token = input()
     auth.set_verifier(token)
     auth.save(os.path.expanduser(OAUTH_TOKEN_FILE))
     print("OAuth token was saved, re-run script to use it.")
@@ -192,10 +192,10 @@ def do_download_photo(dirname, pset, photo, size_label, suffix, get_filename, sk
     try:
         with Timer('save()'):
             photo.save(fname, photo_size_label)
-    except IOError, ex:
+    except IOError as ex:
         logging.warning('IO error saving photo: {}'.format(ex.strerror))
         return
-    except FlickrError, ex:
+    except FlickrError as ex:
         logging.warning('Flickr error saving photo: {}'.format(str(ex)))
         return
 
@@ -320,7 +320,7 @@ def main():
         return 1
 
     if not args.api_key or not args.api_secret:
-        print ('You need to pass in both "api_key" and "api_secret" arguments', file=sys.stderr)
+        print('You need to pass in both "api_key" and "api_secret" arguments', file=sys.stderr)
         return 1
 
     ret = _init(args.api_key, args.api_secret, args.user_auth)
@@ -330,12 +330,12 @@ def main():
     # Replace stdout with a non-strict writer that replaces unknown characters instead of throwing
     # an exception. This "fixes" print issues on the standard Windows terminal, and when there is no
     # terminal at all.
-    if sys.stdout.isatty():
-        default_encoding = sys.stdout.encoding
-    else:
-        default_encoding = locale.getpreferredencoding()
-    if default_encoding != 'utf-8':
-        sys.stdout = codecs.getwriter(default_encoding)(sys.stdout, 'replace')
+    # if sys.stdout.isatty():
+    #     default_encoding = sys.stdout.encoding
+    # else:
+    #     default_encoding = locale.getpreferredencoding()
+    # if default_encoding != 'utf-8':
+    #     sys.stdout = codecs.getwriter(default_encoding)(sys.stdout, 'replace')
 
     if args.list:
         print_sets(args.list)

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,11 @@ setup(name='flickr_download',
       packages=['flickr_download'],
       install_requires=[
           'flickr_api==0.5',
-          'python-dateutil == 1.5',
+          'python-dateutil==2.6.1',
           'PyYAML==3.12',
+      ],
+      dependency_links=[
+          'https://github.com/alexis-mignon/python-flickr-api/archive/master.zip#egg=flickr_api-0.5',
       ],
       test_suite='tests.get_tests',
       tests_require=[


### PR DESCRIPTION
Thought i would add python 3 support. Im still unclear if we need the [codec writer thingie](https://github.com/kirkegaard/flickr-download/blob/master/flickr_download/flick_download.py#L330) since everything in python 3 should be unicode? It'll probably fail the tests since i didnt remove the imports.