### PR TITLE
WIP: Add support for caching flickr_api lib results

### DIFF
--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -153,10 +153,10 @@ def do_download_photo(dirname, pset, photo, size_label, suffix, get_filename, sk
     @param get_filename: Function, function that creates a filename for the photo
     @param skip_download: bool, do not actually download the photo
     """
-    fname = get_full_path(dirname, get_filename(pset, photo, suffix))
+    api_fname = get_full_path(dirname, get_filename(pset, photo, suffix))
 
-    existing = glob.glob(fname + ".*")
-    if glob.glob(fname + ".*"):
+    existing = glob.glob(api_fname + ".???")
+    if existing:
         print('Skipping {0}, as it exists already'.format(', '.join(existing)))
         return
 
@@ -171,7 +171,7 @@ def do_download_photo(dirname, pset, photo, size_label, suffix, get_filename, sk
         else:
             # Fall back for old 'short videos'
             photo_size_label = 'Site MP4'
-        fname = fname + '.mp4'
+        fname = api_fname + '.mp4'
     else:
         photo_size_label = size_label
         suffix = '.jpg'
@@ -186,7 +186,7 @@ def do_download_photo(dirname, pset, photo, size_label, suffix, get_filename, sk
                 if (ext):
                     suffix = ext
 
-        fname = fname + suffix
+        fname = api_fname + suffix
 
     if os.path.exists(fname):
         # TODO: Ideally we should check for file size / md5 here
@@ -200,7 +200,7 @@ def do_download_photo(dirname, pset, photo, size_label, suffix, get_filename, sk
 
     try:
         with Timer('save()'):
-            photo.save(fname, photo_size_label)
+            photo.save(api_fname, photo_size_label)
     except IOError, ex:
         logging.warning('IO error saving photo: {}'.format(ex.strerror))
         return

--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -17,6 +17,7 @@ import sys
 import time
 import pickle
 import signal
+import glob
 
 import flickr_api as Flickr
 from flickr_api.cache import SimpleCache
@@ -153,6 +154,11 @@ def do_download_photo(dirname, pset, photo, size_label, suffix, get_filename, sk
     @param skip_download: bool, do not actually download the photo
     """
     fname = get_full_path(dirname, get_filename(pset, photo, suffix))
+
+    existing = glob.glob(fname + ".*")
+    if glob.glob(fname + ".*"):
+        print('Skipping {0}, as it exists already'.format(', '.join(existing)))
+        return
 
     with Timer('getInfo()'):
         pInfo = photo.getInfo()

--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -265,6 +265,7 @@ def print_sets(username):
     for photo in photosets:
         print('{0} - {1}'.format(photo.id, photo.title))
 
+
 def get_cache(path):
     if not os.path.exists(path):
         cache = SimpleCache(max_entries=20000, timeout=3600)
@@ -272,17 +273,18 @@ def get_cache(path):
         with open(path, 'rb') as handle:
             cache = pickle.load(handle)
             cache.lock = SimpleCache().lock
-    
+
     return cache
 
-    
+
 def save_cache(path, cache):
     cache.lock = None
     with open(path, 'wb') as handle:
         pickle.dump(cache, handle, protocol=pickle.HIGHEST_PROTOCOL)
-    
+
     print('Cache saved')
     return True
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -402,7 +404,7 @@ def main():
                                          args.skip_download)
         except KeyboardInterrupt:
             print('Forcefully aborting. Last photo download might be partial :(', file=sys.stderr)
-        
+
         if cache:
             save_cache(args.cache, cache)
         return 0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='flickr_download',
       license='Apache',
       packages=['flickr_download'],
       install_requires=[
-          'flickr_api==0.5',
+          'flickr_api==0.6.1',
           'python-dateutil == 1.5',
           'PyYAML==3.12',
       ],


### PR DESCRIPTION
As Flickr API is not very fast it would be cool to add an option to use a cache to the external calls so if there's a problem middle backup or you want to run the process continually expensive requests shouldn't be a problem.

For instance I'm trying to backup my personal account with >10k photos and everytime there's a problem in flickr-download I have to wait around 15min for the process to start doing useful work again.

