### PR TITLE
Allow to use profile URL or email instead of username

### DIFF
--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -219,6 +219,18 @@ def download_photo(photo_id, get_filename, size_label, skip_download=False):
     do_download_photo(".", None, photo, size_label, suffix, get_filename, skip_download)
 
 
+def find_user(userid):
+    if userid.startswith("https://") or \
+       userid.startswith("www.flickr.com") or \
+        userid.startswith("flickr.com"):
+        user = Flickr.Person.findByUrl(userid)
+    elif userid.find("@") > 0:
+        user = Flickr.Person.findByEmail(userid)
+    else:
+        user = Flickr.Person.findByUserName(userid)
+    return user
+
+
 def download_user(username, get_filename, size_label, skip_download=False):
     """
     Download all the sets owned by the given user.
@@ -228,7 +240,7 @@ def download_user(username, get_filename, size_label, skip_download=False):
     @param size_label: str|None, size to download (or None for largest available)
     @param skip_download: bool, do not actually download the photo
     """
-    user = Flickr.Person.findByUserName(username)
+    user = find_user(username)
     with Timer('getPhotosets()'):
         photosets = user.getPhotosets()
     for photoset in photosets:
@@ -244,7 +256,7 @@ def download_user_photos(username, get_filename, size_label, skip_download=False
     @param size_label: str|None, size to download (or None for largest available)
     @param skip_download: bool, do not actually download the photo
     """
-    user = Flickr.Person.findByUserName(username)
+    user = find_user(username)
     download_list(user, username, get_filename, size_label, skip_download)
 
 
@@ -255,7 +267,7 @@ def print_sets(username):
     @param username: str,
     """
     with Timer('findByUserName()'):
-        user = Flickr.Person.findByUserName(username)
+        user = find_user(username)
     with Timer('getPhotosets()'):
         photosets = user.getPhotosets()
     for photo in photosets:

--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -266,7 +266,7 @@ def print_sets(username):
 
     @param username: str,
     """
-    with Timer('findByUserName()'):
+    with Timer('find_user()'):
         user = find_user(username)
     with Timer('getPhotosets()'):
         photosets = user.getPhotosets()

--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -221,8 +221,8 @@ def download_photo(photo_id, get_filename, size_label, skip_download=False):
 
 def find_user(userid):
     if userid.startswith("https://") or \
-       userid.startswith("www.flickr.com") or \
-        userid.startswith("flickr.com"):
+            userid.startswith("www.flickr.com") or \
+            userid.startswith("flickr.com"):
         user = Flickr.Person.findByUrl(userid)
     elif userid.find("@") > 0:
         user = Flickr.Person.findByEmail(userid)


### PR DESCRIPTION
It appears that some users cannot be found by findByUserName();
API returns error code 1. Such users can still be referenced by
their email or URL.

Proposed change: use findByEmail and findByUrl methods instead of
findByUserName if the given username appears to be an email (contains `@`)
or a URL (starts with `https://`, `www.flickr.com`, or `flickr.com`.).

Potential issues: users having @ in their username may have to use
URL of their profile instead.

P.S. This is the same as the closed pull request #40, but now from a feature branch.