### PR TITLE
fix #45: crash on an unspecified FlickrError in photo.getInfo()

### DIFF
--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -151,7 +151,7 @@ def do_download_photo(dirname, pset, photo, size_label, suffix, get_filename, sk
     """
     fname = get_full_path(dirname, get_filename(pset, photo, suffix))
 
-    pinfo = {}
+    pInfo = {}
     try:
         with Timer('getInfo()'):
             pInfo = photo.getInfo()

--- a/flickr_download/flick_download.py
+++ b/flickr_download/flick_download.py
@@ -151,8 +151,13 @@ def do_download_photo(dirname, pset, photo, size_label, suffix, get_filename, sk
     """
     fname = get_full_path(dirname, get_filename(pset, photo, suffix))
 
-    with Timer('getInfo()'):
-        pInfo = photo.getInfo()
+    pinfo = {}
+    try:
+        with Timer('getInfo()'):
+            pInfo = photo.getInfo()
+    except FlickrError:
+        print('Skipping {0}, because cannot get info from Flickr'.format(fname))
+        return
 
     if 'video' in pInfo:
         with Timer('getSizes()'):


### PR DESCRIPTION
FlickrError on photo.getInfo doesn't provide any info about what's happening.

As a workaround I tried simply skipping files which give this error, it appears that most of the other files after that are fetched without problems.